### PR TITLE
LTL encoding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
 
   workflow_dispatch:
 
@@ -26,19 +25,3 @@ jobs:
 
       - name: Run tests
         run: bash run_tests.sh
-
-      - name: Build
-        run: bash make_distrib.sh
-
-      # - name: Publish package to TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_TEST_API_TOKEN }}
-      #     repository_url: https://test.pypi.org/legacy/
-
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/examples/ltl2vmt.py
+++ b/examples/ltl2vmt.py
@@ -1,0 +1,59 @@
+#
+#    Copyright 2022 Embedded Systems Unit, Fondazione Bruno Kessler
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+import sys
+import argparse
+from pyvmt.vmtlib.reader import read
+from pyvmt.ltl_encoder import ltl_encode, ltl_circuit_encode
+from pyvmt import exceptions
+
+def parse_args ():
+    '''Defines and parses the arguments'''
+    encoding_algs = {
+        'ltl2smv': ltl_encode,
+        'circuit': ltl_circuit_encode,
+    }
+    parser = argparse.ArgumentParser(description="""Encode a model with an LTL property into a new
+        model where the property has been encoded into a liveness property.
+        Two types of encoding are available,
+        circuit encodes the property by adding monitor circuits,
+        ltl2smv encodes the property into a tableau which is added to the model.
+    """)
+    parser.add_argument('-a', '--alg', choices=encoding_algs.keys(), default='ltl2smv',
+        help="The algorithm to use for encoding")
+    parser.add_argument('-i', type=argparse.FileType('r'), default=sys.stdin, metavar='input',
+        help="The input file, defaults to the standard input", dest='input')
+    parser.add_argument('-o', type=argparse.FileType('w'), default=sys.stdout, metavar='output',
+        help="The output file, defaults to the standard output", dest='output')
+    parser.add_argument('-n', '--idx', type=int, default=0, metavar='property_idx',
+        help="The index of the property to encode")
+    res = parser.parse_args()
+    res.alg = encoding_algs[res.alg]
+    return res
+
+def main():
+    '''Reads a model, encodes the specified LTL property into the model either
+    with the ltl2smv or the circuit encoder, and outputs it.
+    '''
+    args = parse_args()
+    model = read(args.input)
+    prop = model.get_property(args.idx)
+    if not prop.is_ltl():
+        raise exceptions.InvalidPropertyTypeError(f"Expected LTL Property, found {prop.prop_type}")
+    model = args.alg(model, prop.formula)
+    model.serialize(args.output)
+
+if __name__ == '__main__':
+    main()

--- a/pyvmt/ltl_encoder.py
+++ b/pyvmt/ltl_encoder.py
@@ -1,0 +1,168 @@
+#
+#    Copyright 2022 Embedded Systems Unit, Fondazione Bruno Kessler
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+'''
+    Classes and functions used to encode an LTL property.
+'''
+from pysmt.walkers import handles, IdentityDagWalker
+from pyvmt.operators import LTL_F, LTL_G, LTL_R, LTL_U
+from pyvmt.model import Model
+
+# pylint: disable=unused-argument
+
+class LtlRewriter(IdentityDagWalker):
+    '''Walker to normalize an LTL formulae to only the LTL operators X and U'''
+
+    def rewrite(self, formula):
+        '''Rewrite a formula containing LTL to only contain the operators
+        X and U'''
+        return self.walk(formula)
+
+    def walk_ltl_r(self, formula, args, **kwargs):
+        '''fRg -> ¬(¬f U ¬g)'''
+        assert len(args) == 2
+        return self.mgr.Not(self.mgr.U(self.mgr.Not(args[0]), self.mgr.Not(args[1])))
+
+    def walk_ltl_f(self, formula, args, **kwargs):
+        '''Ff -> T U f'''
+        assert len(args) == 1
+        return self.mgr.U(self.mgr.TRUE(), args[0])
+
+    def walk_ltl_g(self, formula, args, **kwargs):
+        '''Gf -> ¬(F ¬f)'''
+        assert len(args) == 1
+        return self.mgr.Not(self.mgr.U(self.mgr.TRUE(), self.mgr.Not(args[0])))
+
+class LtlEncodingWalker(IdentityDagWalker):
+    '''Walker to find the elementary formulae composing an LTL formula, and
+    the associated sat values.
+
+    The walker assumes that the formula has already been rewritten in terms
+    of X, U, and Not, using the LtlRewriter.
+    '''
+
+    def __init__(self, formula, env=None):
+        super().__init__(env=env)
+        self._el_map = {}
+        self._formula = formula
+
+    def get_el_map(self):
+        '''Get the elementary subformulae for the formula.'''
+        self.walk(self._formula)
+        return self._el_map.copy()
+
+    def get_sat(self, formula):
+        '''Get the sat value for a formula.'''
+        return self.walk(formula)
+
+    @handles(LTL_F, LTL_G, LTL_R)
+    def walk_ltl_unsupported(self, formula, args, **kwargs):
+        '''Raise an error on use of unsupported operator'''
+        raise NotImplementedError(
+            f"Formula must not contain {formula.node_type} operators, "\
+            "please, use the LtlRewriter to leave only U and X LTL operators.")
+
+    def walk_ltl_x(self, formula, args, **kwargs):
+        '''
+        el(X f) = el(f) union { X f }
+        sat(X f) = el(X f)
+        '''
+        assert len(args) == 1
+        if formula not in self._el_map:
+            self._el_map[formula] = self.mgr.FreshSymbol(formula.get_type(), 'el_x_%d')
+        return self._el_map[formula]
+
+    def walk_ltl_u(self, formula, args, **kwargs):
+        '''
+        el(f U g) = el(f) union el(g) union { X(f U g) }
+        sat(f U g) = sat(g) | (sat(f) & el(X(f U g)))
+        '''
+        assert len(args) == 2
+        x_formula = self.mgr.X(formula)
+        if x_formula not in self._el_map:
+            stvar = self.mgr.FreshSymbol(formula.get_type(), 'el_u_%d')
+            self._el_map[x_formula] = stvar
+        return self.mgr.Or(args[1], self.mgr.And(args[0], self._el_map[x_formula]))
+
+def _copy_model(model):
+    new_model = Model(env=model.get_env())
+    for state_var in model.get_state_vars():
+        new_model.add_state_var(state_var)
+    for input_var in model.get_input_vars():
+        new_model.add_input_var(input_var)
+    for trans in model.get_trans_constraints():
+        new_model.add_trans(trans)
+    for init in model.get_init_constraints():
+        new_model.add_init(init)
+    return new_model
+
+def ltl_encode(model, formula):
+    '''Encodes an ltl property into a model and returns the new model
+
+    :param model: The model on which to encode the property
+    :type model: pyvmt.model.Model
+    :param prop: The property to encode, must be of type LTL
+    :type prop: pyvmt.properties.Property
+    '''
+    env = model.get_env()
+    mgr = env.formula_manager
+    # rewrite the formula in terms of X and U operators
+    rewriter = LtlRewriter(env=model.get_env())
+    formula = rewriter.rewrite(mgr.Not(formula))
+
+    # get the elementary subformulae
+    el_walker = LtlEncodingWalker(formula, env=model.get_env())
+    el_map = el_walker.get_el_map()
+
+    # create a new model with the same variables and constraints
+    new_model = _copy_model(model)
+    justice = []
+    for el_, stvar in el_map.items():
+        # add variables for the tableau
+        new_model.add_state_var(stvar)
+        sat = el_walker.get_sat(el_.arg(0))
+        # define how the variables evolve
+        new_model.add_trans(mgr.EqualsOrIff(stvar, mgr.Next(sat)))
+        if el_.arg(0).node_type() == LTL_U:
+            # add the required justice
+            justice.append(mgr.Or(mgr.Not(sat), el_walker.get_sat(el_.arg(0).arg(1))))
+    new_model.add_init(el_walker.get_sat(formula))
+
+    if len(justice) != 1:
+        # make single justice
+        just_stvars = {}
+        for just in justice:
+            # add a state variable for each justice, initialized at 0
+            just_stvar = mgr.FreshSymbol(template='J_%d')
+            just_stvars[just] = just_stvar
+            new_model.add_state_var(just_stvar)
+            new_model.add_init(mgr.Iff(just_stvar, mgr.FALSE()))
+        accept = mgr.And(just_stvars.values())
+
+        for just in justice:
+            # add a transition constraint for each justice state variable
+            # once every justice is verified reset the state variables
+            just_stvar = just_stvars[just]
+            new_model.add_trans(
+                mgr.Iff(
+                    mgr.Next(just_stvar),
+                    mgr.Ite(accept, just, mgr.Or(just, just_stvar))
+                )
+            )
+        new_model.add_live_property(mgr.Not(accept))
+    else:
+        new_model.add_live_property(justice[0])
+
+    return new_model

--- a/pyvmt/model.py
+++ b/pyvmt/model.py
@@ -460,7 +460,7 @@ class Model:
         return mgr.Next(formula)
 
     def get_theory(self, extra_formulae=None):
-        '''Get the theory for the whole model, curently ignores properties.
+        '''Get the theory for the whole model, currently ignores properties.
 
         :param extra_formulae: Extra formulae to add, can be used to check the theory
             for the model with the properties, defaults to None
@@ -486,7 +486,7 @@ class Model:
         return theory_out
 
     def get_logic(self, extra_formulae=None):
-        '''Get the closest pysmt logic for the whole model, curently ignores properties.
+        '''Get the closest pysmt logic for the whole model, currently ignores properties.
 
         :param extra_formulae: Extra formulae to add, can be used to check the logic
             for the model with the properties, defaults to None

--- a/pyvmt/operators.py
+++ b/pyvmt/operators.py
@@ -316,18 +316,12 @@ class NNFIzer(pysmt.rewritings.NNFizer):
         mgr = self.mgr
         if formula.is_not():
             s = formula.arg(0)
-            if s.node_type() == LTL_X:
+            if s.node_type() in (LTL_X, LTL_G, LTL_F, NEXT):
                 return [mgr.Not(s.arg(0))]
-            if s.node_type() == LTL_G:
-                return [mgr.Not(s.arg(0))]
-            if s.node_type() == LTL_F:
-                return [mgr.Not(s.arg(0))]
-            if s.node_type() == LTL_U:
+            if s.node_type() in (LTL_U, LTL_R):
                 return [mgr.Not(s.arg(0)), mgr.Not(s.arg(1))]
-            if s.node_type() == LTL_R:
-                return [mgr.Not(s.arg(0)), mgr.Not(s.arg(1))]
-            if s.node_type() == NEXT:
-                return [mgr.Not(s.arg(0))]
+        elif formula.node_type() in (*ALL_LTL, NEXT):
+            return formula.args()
         return super()._get_children(formula)
 
     def walk_not(self, formula, args, **kwargs):
@@ -345,3 +339,7 @@ class NNFIzer(pysmt.rewritings.NNFizer):
         if s.node_type() == NEXT:
             return self.mgr.Next(args[0])
         return super().walk_not(formula, args, **kwargs)
+
+    @handles(*ALL_LTL, NEXT)
+    def walk_other(self, formula, args, **kwargs):
+        return IdentityDagWalker.super(self, formula, args, **kwargs)

--- a/pyvmt/operators.py
+++ b/pyvmt/operators.py
@@ -29,6 +29,7 @@ from pysmt.operators import new_node_type
 from pysmt.type_checker import SimpleTypeChecker
 from pysmt.oracles import FreeVarsOracle, TheoryOracle, QuantifierOracle
 from pysmt.walkers import handles, IdentityDagWalker, DagWalker
+import pysmt.rewritings
 import pysmt.formula
 import pysmt.printers
 import pysmt.operators as op
@@ -127,7 +128,7 @@ FreeVarsOracle.set_handler(FreeVarsOracle.walk_simple_args, NEXT)
 LTL_TYPE_TO_STR = { LTL_X: "X", LTL_F: "F", LTL_G: "G"}
 
 class HRPrinter(pysmt.printers.HRPrinter):
-    '''Extension of the PySmt HRPrinter, prints formuale in a human readable format
+    '''Extension of the PySmt HRPrinter, prints formulae in a human readable format
     '''
     #pylint: disable=missing-function-docstring
 
@@ -151,7 +152,7 @@ class HRPrinter(pysmt.printers.HRPrinter):
         self.stream.write("'")
 
 class HRSerializer(pysmt.printers.HRSerializer):
-    '''Extension of the PySmt HRSerializer, serializes formuale in a human readable format
+    '''Extension of the PySmt HRSerializer, serializes formulae in a human readable format
     '''
     PrinterClass = HRPrinter
 
@@ -304,3 +305,43 @@ class NextPusher(IdentityDagWalker):
         :rtype: pysmt.fnode.FNode
         '''
         return self.walk(formula)
+
+class NNFIzer(pysmt.rewritings.NNFizer):
+    '''Extension of pySMT's NNFizer.
+
+    Converts a formula that may contain LTL operators into Negation Normal Form.
+    '''
+
+    def _get_children(self, formula):
+        mgr = self.mgr
+        if formula.is_not():
+            s = formula.arg(0)
+            if s.node_type() == LTL_X:
+                return [mgr.Not(s.arg(0))]
+            if s.node_type() == LTL_G:
+                return [mgr.Not(s.arg(0))]
+            if s.node_type() == LTL_F:
+                return [mgr.Not(s.arg(0))]
+            if s.node_type() == LTL_U:
+                return [mgr.Not(s.arg(0)), mgr.Not(s.arg(1))]
+            if s.node_type() == LTL_R:
+                return [mgr.Not(s.arg(0)), mgr.Not(s.arg(1))]
+            if s.node_type() == NEXT:
+                return [mgr.Not(s.arg(0))]
+        return super()._get_children(formula)
+
+    def walk_not(self, formula, args, **kwargs):
+        s = formula.arg(0)
+        if s.node_type() == LTL_X:
+            return self.mgr.X(args[0])
+        if s.node_type() == LTL_G:
+            return self.mgr.F(args[0])
+        if s.node_type() == LTL_F:
+            return self.mgr.G(args[0])
+        if s.node_type() == LTL_U:
+            return self.mgr.R(args[0], args[1])
+        if s.node_type() == LTL_R:
+            return self.mgr.U(args[0], args[1])
+        if s.node_type() == NEXT:
+            return self.mgr.Next(args[0])
+        return super().walk_not(formula, args, **kwargs)

--- a/pyvmt/solvers/traces.py
+++ b/pyvmt/solvers/traces.py
@@ -49,7 +49,7 @@ class TraceStep:
         '''Gets a copy of the assignments
 
         :return: The assignments within this step
-        :rtype: Dict[pysmt.fnode.FNode, pysmt.fnode.FNode]
+        :rtype: { pysmt.fnode.FNode: pysmt.fnode.FNode }
         '''
         return self._assignments.copy()
 
@@ -327,7 +327,7 @@ class Trace:
         '''Get a copy of the list of steps in the trace
 
         :return: The list of steps
-        :rtype: List[pyvmt.solvers.traces.TraceStep]
+        :rtype: [pyvmt.solvers.traces.TraceStep]
         '''
         return self._steps.copy()
 

--- a/pyvmt/test/test_ltl.py
+++ b/pyvmt/test/test_ltl.py
@@ -16,14 +16,17 @@
 '''Test the LTL operators of PyVmt
 '''
 
+from io import StringIO
 import sys
 from unittest import TestCase
 import pytest
-from io import StringIO
-from pysmt.shortcuts import Symbol, Iff, And
+from pysmt.shortcuts import Symbol, Iff, And, Or, Not, TRUE
+from pyvmt.shortcuts import Next, F, X, G, U, R
 from pyvmt.environment import reset_env, get_env
-from pyvmt.operators import HasLtlOperatorsWalker
+from pyvmt.operators import HasLtlOperatorsWalker, NNFIzer
 from pyvmt.vmtlib.printers import VmtPrinter, VmtDagPrinter
+from pyvmt.model import Model
+from pyvmt.ltl_encoder import ltl_encode, LtlEncodingWalker, LtlRewriter
 
 class TestLtl(TestCase):
     '''
@@ -85,6 +88,98 @@ class TestLtl(TestCase):
         self.assertEqual(mgr.G(x).serialize(), '(G x)')
         self.assertEqual(mgr.U(x, y).serialize(), '(x U y)')
         self.assertEqual(mgr.R(x, y).serialize(), '(x R y)')
+
+    def test_nnfizer(self):
+        '''Test the NNFizer for the LTL operators'''
+        mgr = get_env().formula_manager
+        walker = NNFIzer()
+        a = Symbol('a')
+        b = Symbol('b')
+        c = Symbol('c')
+        f = And(a, Next(b))
+        g = Or(a, c)
+        negated_f = Or(Not(a), Next(Not(b)))
+        negated_g = And(Not(a), Not(c))
+        self.assertEqual(walker.convert(mgr.Not(mgr.X(f))),
+            mgr.X(negated_f))
+        self.assertEqual(walker.convert(mgr.Not(mgr.G(f))),
+            mgr.F(negated_f))
+        self.assertEqual(walker.convert(mgr.Not(mgr.G(f))),
+            mgr.F(negated_f))
+        self.assertEqual(walker.convert(mgr.Not(mgr.U(f, g))),
+            mgr.R(negated_f, negated_g))
+        self.assertEqual(walker.convert(mgr.Not(mgr.R(f, g))),
+            mgr.U(negated_f, negated_g))
+
+    def test_ltl_rewriter(self):
+        '''Test that the LTL rewriter works correctly'''
+        rewriter = LtlRewriter()
+        x = Symbol('x')
+        y = Symbol('y')
+        z = Symbol('z')
+        f = And(x, y)
+        self.assertEqual(rewriter.rewrite(X(f)), X(f))
+        self.assertEqual(rewriter.rewrite(U(z, f)), U(z, f))
+        self.assertEqual(rewriter.rewrite(R(z, f)),
+            Not(U(Not(z), Not(f)))
+        )
+        self.assertEqual(rewriter.rewrite(F(f)), U(TRUE(), f))
+        self.assertEqual(rewriter.rewrite(G(f)), Not(U(TRUE(), Not(f))))
+
+    def test_ltl_encoding_walker(self):
+        '''Test the LtlEncodingWalker, check the elementary subformulae and sat values'''
+        x = Symbol('x')
+        y = Symbol('y')
+        z = Symbol('z')
+        el1 = X(And(x, y))
+        el0 = U(x, z)
+        f = And(el1, el0)
+        walker = LtlEncodingWalker(f)
+        el = walker.get_el_map()
+        self.assertSetEqual(set(el), { el1, X(el0) })
+
+        self.assertEqual(walker.get_sat(el0),
+            Or(z, And(x, el[X(el0)])))
+        self.assertEqual(walker.get_sat(el1.arg(0)),
+            And(x, y))
+
+    def test_ltl_encode(self):
+        '''Test the ltl encoding procedure'''
+        x = Symbol('x')
+        y = Symbol('y')
+        z = Symbol('z')
+        el0 = U(x, z)
+        el1 = X(And(x, y))
+        f = And(el1, el0)
+
+        model = Model()
+        model.add_state_var(x)
+        model.add_state_var(y)
+        model.add_state_var(z)
+        new_model = ltl_encode(model, f)
+
+        el_u_0 = Symbol('el_u_0')
+        el_x_1 = Symbol('el_x_1')
+
+        self.assertSetEqual(set(new_model.get_trans_constraints()),
+            set([
+                Iff(
+                    el_u_0,
+                    Next(Or(z, And(x, el_u_0)))
+                ),
+                Iff(
+                    el_x_1,
+                    Next(And(x, y))
+                )
+            ]))
+        self.assertSetEqual(set(new_model.get_init_constraints()),
+            set([
+                Not(And(el_x_1, Or(z, And(x, el_u_0))))
+            ])
+        )
+        self.assertEqual(new_model.get_live_properties()[0].formula,
+            Or(Not(Or(z, And(x, el_u_0))) , z))
+        new_model.get_live_properties()
 
 if __name__ == '__main__':
     pytest.main(sys.argv)

--- a/pyvmt/test/test_ltl.py
+++ b/pyvmt/test/test_ltl.py
@@ -167,7 +167,7 @@ class TestLtl(TestCase):
         el_u_0 = Symbol('el_u_0')
         el_x_1 = Symbol('el_x_1')
 
-        self.assertSetEqual(set(new_model.get_trans_constraints()),
+        self.assertSetEqual(set(new_model.get_trans_constraints()[0:2]),
             set([
                 Iff(
                     el_u_0,
@@ -178,13 +178,13 @@ class TestLtl(TestCase):
                     Next(And(x, y))
                 )
             ]))
-        self.assertSetEqual(set(new_model.get_init_constraints()),
+        self.assertSetEqual(set(new_model.get_init_constraints()[0:1]),
             set([
                 Not(And(el_x_1, Or(z, And(x, el_u_0))))
             ])
         )
         self.assertEqual(new_model.get_live_properties()[0].formula,
-            Or(Not(Or(z, And(x, el_u_0))) , z))
+            Not(Symbol('J_2')))
         new_model.get_live_properties()
 
     def test_circuit_encoding_walker(self):

--- a/pyvmt/vmtlib/reader.py
+++ b/pyvmt/vmtlib/reader.py
@@ -17,6 +17,7 @@
     Exports a reader for VMT-LIB scripts
 '''
 
+import pysmt.exceptions
 from pyvmt.vmtlib.parser import VmtLibParser
 from pyvmt.environment import get_env
 from pyvmt.model import Model
@@ -53,12 +54,15 @@ def read(stream, env=None):
         # check if there there is exactly one next annotation for the formula
 
         for annotation in annotations:
-            next_variable = mgr.get_symbol(annotation)
+            try:
+                next_variable = mgr.get_symbol(annotation)
+            except pysmt.exceptions.UndefinedSymbolError:
+                next_variable = mgr.Symbol(annotation, typename=formula.get_type())
             model.add_state_var(formula)
 
             # remove the state variable curr and next from the extra declarations
-            extra_declarations.remove(formula)
-            extra_declarations.remove(next_variable)
+            extra_declarations.discard(formula)
+            extra_declarations.discard(next_variable)
             next_replacements[next_variable] = mgr.Next(formula)
 
         # there should only be one annotation


### PR DESCRIPTION
Added functions to encode an LTL property into a model:
- ltl_encode which implements the ltl2smv algorithm
- ltl_circuit_encode which implements encoding through circuit monitors

An example ltl2vmt.py has been added that runs the encoder on the specified property using the algorithm chosen by the user through command line interface.