### PR TITLE
Return inductive invariant when the property is invalid (Ic3ia)

### DIFF
--- a/pyvmt/model.py
+++ b/pyvmt/model.py
@@ -181,6 +181,14 @@ class Model:
         '''
         return list(self._inputs)
 
+    def get_all_vars(self):
+        '''Returns a list of the model's variables
+
+        :return: A list containing the model variables
+        :rtype: List[pysmt.fnode.FNode]
+        '''
+        return self.get_state_vars() + self.get_input_vars()
+
     def add_invar(self, formula):
         '''Add a new invariant to the model.
         Since an invariant adds both an init and a trans constraint,

--- a/pyvmt/test/test_model.py
+++ b/pyvmt/test/test_model.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 import pytest
 from pysmt import typing
 from pysmt.shortcuts import Equals, Plus, Int, Symbol, Iff, GE, And, TRUE, Times, Exists
-from pysmt.logics import QF_BOOL, QF_IDL, QF_LIA, QF_UFLIRA, UFLIRA
+from pysmt.logics import QF_BOOL, QF_IDL, QF_LIA, QF_UFLIRA, UFLIRA, QF_LIRA
 from pyvmt.environment import reset_env, get_env
 from pyvmt.model import Model
 from pyvmt import exceptions
@@ -327,7 +327,7 @@ class TestModel(TestCase):
         self.assertEqual(model.get_logic(), QF_LIA)
 
         model.create_state_var('z', typing.REAL)
-        self.assertEqual(model.get_logic(), QF_UFLIRA)
+        self.assertEqual(model.get_logic(), QF_LIRA)
         self.assertEqual(model.get_logic([Exists([y], And(Next(x), Equals(y, Int(0))))]), UFLIRA)
 
         model.add_trans(Exists([y], And(Next(x), Equals(y, Int(0)))))


### PR DESCRIPTION
Ic3ia returns an inductive invariant when the property is valid.
In this pull request, I extended the Ic3ia solver class to get the invariant from ic3ia output and to return it as part of the checker result.